### PR TITLE
add support for using CacheKit in static libraries

### DIFF
--- a/CacheKit.podspec
+++ b/CacheKit.podspec
@@ -15,10 +15,26 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
   s.requires_arc = true
 
-  s.source_files = 'Pod/Classes'
+  s.default_subspec = 'standard'
+
   s.resource_bundles = {
     'CacheKit' => ['Pod/Assets/*.png']
   }
-  
-  s.dependency 'FMDB', '~> 2.4'
+
+  s.subspec 'common' do |ss|
+      ss.source_files = 'Pod/Classes'
+  end
+
+  # use the standard FMDB version
+  s.subspec 'standard' do |ss|
+    ss.dependency 'FMDB', '~> 2.4'
+    ss.dependency 'CacheKit/common'
+  end
+
+  # use the standalone FMDB version
+  s.subspec 'standalone' do |ss|
+    ss.dependency 'FMDB/standalone', '~> 2.4'
+    ss.dependency 'CacheKit/common'
+  end
+
 end


### PR DESCRIPTION
I've splitted the CacheKit podspec into subspecs, because in a static library the FMDB/standard pod can't be used. Instead of that the FMDB/standalone should be used. This way the developers can choose between the solutions.
