### PR TITLE
Fix podspec for validation + set version to 0.1.1

### DIFF
--- a/CacheKit.podspec
+++ b/CacheKit.podspec
@@ -17,20 +17,16 @@ Pod::Spec.new do |s|
     'CacheKit' => ['Pod/Assets/*.png']
   }
 
-  s.subspec 'common' do |ss|
-      ss.source_files = 'Pod/Classes'
-  end
-
   # use the standard FMDB version
   s.subspec 'standard' do |ss|
     ss.dependency 'FMDB', '~> 2.4'
-    ss.dependency 'CacheKit/common'
+    ss.source_files = 'Pod/Classes'
   end
 
   # use the standalone FMDB version
   s.subspec 'standalone' do |ss|
     ss.dependency 'FMDB/standalone', '~> 2.4'
-    ss.dependency 'CacheKit/common'
+    ss.source_files = 'Pod/Classes'
   end
 
 end

--- a/CacheKit.podspec
+++ b/CacheKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CacheKit"
-  s.version          = "0.1.0"
+  s.version          = "0.1.1"
   s.summary          = "Easily cache objects in memory, to files, a database or not at all."
   s.homepage         = "https://github.com/davbeck/CacheKit"
   s.license          = 'MIT'


### PR DESCRIPTION
I fixed my previously changed lines in the podspec.
Now it can pass through the pod lint validation.

Plus: I increased the version to 0.1.1 and added a tag for it.

Please submit the new version to the official CocoaPods Specs repository.

BR,
Roland