### PR TITLE
objectInMemoryForKey returning  wrong type when used internal  

### DIFF
--- a/Pod/Classes/CKMemoryCache.m
+++ b/Pod/Classes/CKMemoryCache.m
@@ -71,7 +71,7 @@
 }
 
 
-- (id)objectInMemoryForKeyInternal:(NSString *)key
+- (CKCacheContent*)objectInMemoryForKeyInternal:(NSString *)key
 {
     CKCacheContent *cacheContent = [_internalCache objectForKey:key];
 

--- a/Pod/Classes/CKMemoryCache.m
+++ b/Pod/Classes/CKMemoryCache.m
@@ -52,7 +52,7 @@
 
 - (id)objectForKey:(NSString *)key expires:(NSDate *)expires withContent:(id(^)())content
 {
-    CKCacheContent *cacheContent = [self objectInMemoryForKey:key];
+    CKCacheContent *cacheContent = [self objectInMemoryForKeyInternal:key];
     
     if (cacheContent == nil && content != nil) {
         id object = content();
@@ -67,15 +67,22 @@
 
 - (id)objectInMemoryForKey:(NSString *)key
 {
-	CKCacheContent *cacheContent = [_internalCache objectForKey:key];
-	
-	if (cacheContent.expires.timeIntervalSinceNow < 0.0) {
-		[_internalCache removeObjectForKey:key];
-		cacheContent = nil;
-	}
-	
-	return cacheContent.object;
+    return [self objectInMemoryForKeyInternal:key].object;
 }
+
+
+- (id)objectInMemoryForKeyInternal:(NSString *)key
+{
+    CKCacheContent *cacheContent = [_internalCache objectForKey:key];
+
+    if (cacheContent.expires.timeIntervalSinceNow < 0.0) {
+        [_internalCache removeObjectForKey:key];
+        cacheContent = nil;
+    }
+
+    return cacheContent;
+}
+
 
 
 - (void)setObject:(id)object forKey:(NSString *)key expires:(NSDate *)expires


### PR DESCRIPTION
Hi
while using this Lib, I found that the 
objectForKey:(NSString *)key expires:(NSDate *)expires withContent:(id(^)())content

was expecting a CKCacheContent, but was getting the underlying object back instead  